### PR TITLE
EncodeBuilder: Correcting which type of controls should be written in…

### DIFF
--- a/encode_builder.go
+++ b/encode_builder.go
@@ -1,7 +1,5 @@
 package gojay
 
-const hex = "0123456789abcdef"
-
 // grow grows b's capacity, if necessary, to guarantee space for
 // another n bytes. After grow(n), at least n bytes can be written to b
 // without another allocation. If n is negative, grow panics.
@@ -36,13 +34,13 @@ func (enc *Encoder) writeString(s string) {
 }
 
 func (enc *Encoder) writeStringEscape(s string) {
-	l := len(s)
-	for i := 0; i < l; i++ {
+	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if c >= 0x20 && c != '\\' && c != '"' {
 			enc.writeByte(c)
 			continue
 		}
+
 		switch c {
 		case '\\', '"':
 			enc.writeTwoBytes('\\', c)
@@ -56,10 +54,6 @@ func (enc *Encoder) writeStringEscape(s string) {
 			enc.writeTwoBytes('\\', 'r')
 		case '\t':
 			enc.writeTwoBytes('\\', 't')
-		default:
-			enc.writeString(`\u00`)
-			enc.writeTwoBytes(hex[c>>4], hex[c&0xF])
 		}
-		continue
 	}
 }

--- a/encode_builder_test.go
+++ b/encode_builder_test.go
@@ -1,1 +1,80 @@
 package gojay
+
+import (
+	"bytes"
+	"testing"
+)
+
+// https://www.ascii-code.com/
+func Test_writeStringEscape(t *testing.T) {
+	type args struct {
+		stringAsByte int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should not write a null byte to a string",
+			args: args{
+				stringAsByte: 0,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a bell byte to a string",
+			args: args{
+				stringAsByte: 7,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a vertical tab byte to a string",
+			args: args{
+				stringAsByte: 11,
+			},
+			want: "",
+		},
+		{
+			name: "should not write a shift in byte to a string",
+			args: args{
+				stringAsByte: 15,
+			},
+			want: "",
+		},
+		{
+			name: "should not write an escape byte to a string",
+			args: args{
+				stringAsByte: 27,
+			},
+			want: "",
+		},
+		{
+			name: "should write a horizontal tab byte to a string",
+			args: args{
+				stringAsByte: 9,
+			},
+			want: "\\t",
+		},
+		{
+			name: "should write an at byte to a string",
+			args: args{
+				stringAsByte: 64,
+			},
+			want: "@",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := new(bytes.Buffer)
+			e := NewEncoder(b)
+			e.writeStringEscape(string(rune(tt.args.stringAsByte)))
+			got := string(e.buf)
+			if got != tt.want {
+				t.Fatalf("writeStringEscape() got %s want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/encode_string_test.go
+++ b/encode_string_test.go
@@ -92,18 +92,6 @@ func TestEncoderStringEncodeAPI(t *testing.T) {
 			builder.String(),
 			"Result of marshalling is different as the one expected")
 	})
-	t.Run("escaped-control-char", func(t *testing.T) {
-		str := "\u001b"
-		builder := &strings.Builder{}
-		enc := NewEncoder(builder)
-		err := enc.EncodeString(str)
-		assert.Nil(t, err, "Error should be nil")
-		assert.Equal(
-			t,
-			`"\u001b"`,
-			builder.String(),
-			"Result of marshalling is different as the one expected")
-	})
 	t.Run("escaped-sequence3", func(t *testing.T) {
 		str := "hello \f world 𝄞"
 		builder := &strings.Builder{}


### PR DESCRIPTION
… a JSON string

According to the spec https://www.json.org/json-en.html these are the only valid
controls

\b  Backspace (ascii code 08)
\f  Form feed (ascii code 0C)
\n  New line
\r  Carriage return
\t  Tab
\"  Double quote
\\  Backslash character