### PR TITLE
Decode: cast to a uint64 to allow for double digit large numbers

### DIFF
--- a/decode_number_float.go
+++ b/decode_number_float.go
@@ -116,7 +116,7 @@ func (dec *Decoder) getFloat() (float64, error) {
 			continue
 		case '.':
 			// we get part before decimal as integer
-			beforeDecimal := dec.atoi64(start, end)
+			beforeDecimal := uint64(dec.atoi64(start, end))
 			// then we get part after decimal as integer
 			start = j + 1
 			// get number after the decimal point
@@ -145,7 +145,7 @@ func (dec *Decoder) getFloat() (float64, error) {
 					}
 					dec.cursor = i + 1
 					pow := pow10uint64[expI]
-					floatVal := float64(beforeDecimal+afterDecimal) / float64(pow)
+					floatVal := float64(beforeDecimal) + float64(afterDecimal)/float64(pow)
 					exp, err := dec.getExponent()
 					if err != nil {
 						return 0, err
@@ -323,7 +323,7 @@ func (dec *Decoder) getFloat32() (float32, error) {
 			continue
 		case '.':
 			// we get part before decimal as integer
-			beforeDecimal := dec.atoi64(start, end)
+			beforeDecimal := uint64(dec.atoi64(start, end))
 			// then we get part after decimal as integer
 			start = j + 1
 			// get number after the decimal point
@@ -353,7 +353,7 @@ func (dec *Decoder) getFloat32() (float32, error) {
 					pow := pow10uint64[expI]
 					// then we add both integers
 					// then we divide the number by the power found
-					floatVal := float32(beforeDecimal+afterDecimal) / float32(pow)
+					floatVal := float32(beforeDecimal) + float32(afterDecimal)/float32(pow)
 					exp, err := dec.getExponent()
 					if err != nil {
 						return 0, err
@@ -388,7 +388,7 @@ func (dec *Decoder) getFloat32() (float32, error) {
 				afterDecimal = dec.atoi64(start, end)
 			}
 			pow := pow10uint64[expI]
-			return float32(beforeDecimal+afterDecimal) / float32(pow), nil
+			return float32(beforeDecimal) + float32(afterDecimal)/float32(pow), nil
 		case 'e', 'E':
 			dec.cursor = j + 1
 			// we get part before decimal as integer


### PR DESCRIPTION
This will break if the before value is 3 digits and and the sum of post and pre decimal numbers exceed uint64, the solution if needed would be to use the big.Math package if needed